### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/feryanuar24/lpmunsika/security/code-scanning/6](https://github.com/feryanuar24/lpmunsika/security/code-scanning/6)

In general, this problem is fixed by explicitly defining the minimal required `GITHUB_TOKEN` permissions in the workflow, either at the root level (for all jobs) or per job. Since this workflow only needs to check out code and deploy via FTP using secrets, it only needs read access to repository contents, so `contents: read` is sufficient.

The best fix without changing functionality is to add a `permissions:` block with `contents: read` at the workflow root, just below the `on:` section (or above `jobs:`). This will apply to all jobs in the workflow, including `deploy`, unless overridden. No steps need to change, and no additional permissions (like `packages`, `pull-requests`, or `issues`) appear necessary based on the shown code.

Concretely:
- Edit `.github/workflows/deploy.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after the trigger block (`on:`) and before the `jobs:` key (or equivalently between line 6 and line 7 in the provided snippet). No imports, methods, or other definitions are required because this is purely a workflow configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
